### PR TITLE
updating to allow custom settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0-RC1"
+        "craftcms/cms": "^3.0.0-RC1",
+        "sabberworm/php-css-parser": "^8.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/fields/EntryInstructionsField.php
+++ b/src/fields/EntryInstructionsField.php
@@ -29,6 +29,8 @@ class EntryInstructionsField extends Field
 {
     // Public Properties
     // =========================================================================
+    
+    public $fieldCustomCss = '';
 
     // Static Methods
     // =========================================================================
@@ -39,6 +41,17 @@ class EntryInstructionsField extends Field
     public static function displayName (): string
     {
         return Craft::t('entry-instructions', 'Entry Instructions');
+    }
+
+
+    public function getSettingsHtml()
+    {
+        return Craft::$app->getView()->renderTemplate(
+            'entry-instructions/_components/fields/EntryInstructionsField_settings',
+            [
+                'field' => $this,
+            ]
+        );
     }
 
     /**
@@ -59,7 +72,21 @@ class EntryInstructionsField extends Field
                 'field'        => $this,
                 'id'           => $id,
                 'namespacedId' => $namespacedId,
+                'customCSS'    => $this->getAndParseCSS($id)
             ]
         );
+    }
+
+    private function getAndParseCSS($id) {
+        $settings = $this->getSettings();
+        $CssParser = new \Sabberworm\CSS\Parser($settings['fieldCustomCss']);
+        $parsedCss = $CssParser->parse();
+        foreach($parsedCss->getAllDeclarationBlocks() as $oBlock) {
+            foreach($oBlock->getSelectors() as $oSelector) {
+                //Loop over all selector parts (the comma-separated strings in a selector) and prepend the id
+                $oSelector->setSelector("#fields-{$id}-field .heading .instructions ".$oSelector->getSelector());
+            }
+        }
+        return $parsedCss->render();
     }
 }

--- a/src/templates/_components/fields/EntryInstructionsField_input.twig
+++ b/src/templates/_components/fields/EntryInstructionsField_input.twig
@@ -13,6 +13,7 @@
  */
 #}
 <style type="text/css">
+/* DEFAULT CSS */
         #fields-{{ id }}-field .heading label {
                 display: none;
         }
@@ -62,4 +63,7 @@
         #fields-{{ id }}-field .heading .instructions h6 { font-size:  9px; }
         #fields-{{ id }}-field .heading .instructions p { max-width: 70%; }
         #fields-{{ id }}-field .heading .instructions a { text-decoration: underline; }
+
+/* EXTRA CUSTOM CSS */
+{{ customCSS }}
 </style>

--- a/src/templates/_components/fields/EntryInstructionsField_settings.twig
+++ b/src/templates/_components/fields/EntryInstructionsField_settings.twig
@@ -1,0 +1,11 @@
+{% import "_includes/forms" as forms %}
+
+{{ forms.textAreaField({
+    label: 'Custom CSS',
+    instructions: 'Custom CSS, which must be valid',
+    rows: 16,
+    id: 'fieldCustomCss',
+    name: 'fieldCustomCss',
+    value: field['fieldCustomCss'],
+    errors: field.getErrors('fieldCustomCss')
+}) }}


### PR DESCRIPTION
This allows per-field custom CSS. It keeps the basic defaults but writes anything the user enters *after* all the default CSS, so anything can be overridden. It uses a CSS parser to prepend the field ID/class information, so no one has to worry about adding all the specific crap - just very simple selectors.